### PR TITLE
Correct time to utc

### DIFF
--- a/ncas_radar_wind_profiler_1/core/wind_profiler_netcdf.py
+++ b/ncas_radar_wind_profiler_1/core/wind_profiler_netcdf.py
@@ -46,7 +46,6 @@ amof_version = "2.0"
 # These are all attributes so far
 processing_software_version = 'v1.0'  
 processing_software_url = subprocess.check_output(["git", "remote", "-v"]).split()[1].decode().replace('git@github.com:','https://github.com/')
-#processing_software_url = 'https://github.com/ncasuk/ncas-radar-wind-profiler-1-software' 
 
 # hopefully I can work out how to get this from the release itself
 amf_vocabularies_release = 'https://github.com/ncasuk/AMF_CVs/releases/tag/v2.0.0'

--- a/ncas_radar_wind_profiler_1/core/wind_profiler_netcdf.py
+++ b/ncas_radar_wind_profiler_1/core/wind_profiler_netcdf.py
@@ -27,6 +27,7 @@ from netCDF4 import Dataset
 import numpy as np
 import datetime as dt
 import argparse
+import subprocess
 
 from ..util import create_netcdf as create_netcdf
 from ..util import add_datasets as add_datasets
@@ -44,7 +45,8 @@ amof_version = "2.0"
 
 # These are all attributes so far
 processing_software_version = 'v1.0'  
-processing_software_url = 'https://github.com/ncasuk/ncas-radar-wind-profiler-1-software' 
+processing_software_url = subprocess.check_output(["git", "remote", "-v"]).split()[1].decode().replace('git@github.com:','https://github.com/')
+#processing_software_url = 'https://github.com/ncasuk/ncas-radar-wind-profiler-1-software' 
 
 # hopefully I can work out how to get this from the release itself
 amf_vocabularies_release = 'https://github.com/ncasuk/AMF_CVs/releases/tag/v2.0.0'

--- a/ncas_radar_wind_profiler_1/core/wind_profiler_netcdf.py
+++ b/ncas_radar_wind_profiler_1/core/wind_profiler_netcdf.py
@@ -33,7 +33,6 @@ from ..util import add_datasets as add_datasets
 from ..util import helpful_functions as hf
 from . import wpufambinary_read33 as read33
 
-
     
 
 #################################
@@ -217,10 +216,10 @@ def main(all_trw_files, processing_software_version=processing_software_version,
                     
     # Can now add in values to time_coverage_start and time_coverage_end global attrs
     first_time = ncfile['time'][0]  # should be unix time
-    first_time = dt.datetime.fromtimestamp(int(first_time))
+    first_time = dt.datetime.fromtimestamp(int(first_time), dt.timezone.utc)
     ncfile.time_coverage_start = first_time.strftime('%Y-%m-%dT%H:%M:%S')
     last_time = ncfile['time'][-1]  # should be unix time
-    last_time = dt.datetime.fromtimestamp(int(last_time))
+    last_time = dt.datetime.fromtimestamp(int(last_time), dt.timezone.utc)
     ncfile.time_coverage_end = last_time.strftime('%Y-%m-%dT%H:%M:%S')
     
     

--- a/ncas_radar_wind_profiler_1/core/wpufambinary_read33.py
+++ b/ncas_radar_wind_profiler_1/core/wpufambinary_read33.py
@@ -109,7 +109,7 @@ def main(full_filename, verbose=0, classification=0, variance_test=1):
     minutes = int(filename[6:8])
     
     # create datetime object
-    date_time_from_filename = dt.datetime(year, month, day, hour, minutes)
+    date_time_from_filename = dt.datetime(year, month, day, hour, minutes, tzinfo=dt.timezone.utc)
     
     time_in_minutes_since_start_of_day = date_time_from_filename.hour*60 + date_time_from_filename.minute
     time_in_seconds_since_start_of_day = time_in_minutes_since_start_of_day*60
@@ -129,7 +129,7 @@ def main(full_filename, verbose=0, classification=0, variance_test=1):
     # TRANSLATE THE FILE #
     ######################
     
-    # idl code lins 364 - 434
+    # idl code lines 364 - 434
     # first line
     
     # first two bytes are ignored
@@ -154,14 +154,14 @@ def main(full_filename, verbose=0, classification=0, variance_test=1):
     # 11th and 12th bytes are ignored
     # start date - 13th-16th bytes (well, 16th-13th), unix time
     start_date_unix = int(f"0b{decimalToBinary(data[15])}{decimalToBinary(data[14])}{decimalToBinary(data[13])}{decimalToBinary(data[12])}",2)
-    start_date = dt.datetime.fromtimestamp(start_date_unix)
+    start_date = dt.datetime.fromtimestamp(start_date_unix, dt.timezone.utc)
     
     # get day of year from this time stamp
     day_of_year = start_date.timetuple().tm_yday
     
     # end date is 17th-20th bytes
     end_date_unix = int(f"0b{decimalToBinary(data[19])}{decimalToBinary(data[18])}{decimalToBinary(data[17])}{decimalToBinary(data[16])}",2)
-    end_date = dt.datetime.fromtimestamp(end_date_unix)
+    end_date = dt.datetime.fromtimestamp(end_date_unix, dt.timezone.utc)
     
     # 21st and 22nd bytes - update rate
     update_rate = int(f"0b{decimalToBinary(data[21])}{decimalToBinary(data[20])}",2)


### PR DESCRIPTION
Datetime objects had previously been timezone naive, and so datetime objects were working on BST rather than UTC, causing inconsistencies. Those objects have now been made timezone aware.