### PR TITLE
Minor bug fixes

### DIFF
--- a/process_wp.py
+++ b/process_wp.py
@@ -145,8 +145,8 @@ def make_netcdf_snr_winds(trw_files, metadata_file = None, ncfile_location = '.'
     util.update_variable(ncfile, 'time_minutes_since_start_of_day', time_minutes_since_start_of_day)
     
     
-    ncfile.setncattr('time_coverage_start', dt.datetime.fromtimestamp(min(all_time_coverage_start_dt), dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S %Z"))
-    ncfile.setncattr('time_coverage_end', dt.datetime.fromtimestamp(max(all_time_coverage_end_dt), dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S %Z"))
+    ncfile.setncattr('time_coverage_start', dt.datetime.fromtimestamp(min(all_time_coverage_start_dt), dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S"))
+    ncfile.setncattr('time_coverage_end', dt.datetime.fromtimestamp(max(all_time_coverage_end_dt), dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S"))
     ncfile.setncattr('platform', 'cdao')
     ncfile.setncattr('platform_altitude', all_attrs['platform_altitude'][0])
     ncfile.setncattr('geospatial_bounds', all_attrs['geospatial_bounds'][0])

--- a/scripts/make_netcdf.sh
+++ b/scripts/make_netcdf.sh
@@ -38,9 +38,9 @@ case $month in
 esac
 
 
-trt0_files=$(ls ${filepath_trt0}/${year}/${month}/${year}${anmonth}${day}.TRT/*)
+trt0_files=$(ls ${filepath_trt0}/${year}/${month}/${year}${anmonth}${day}.TRT/*.trw)
 no_trt0_files=$(ls ${filepath_trt0}/${year}/${month}/${year}${anmonth}${day}.TRT/* | wc -l)
-trt1_files=$(ls ${filepath_trt1}/${year}/${month}/${year}${anmonth}${day}.TRT/*)
+trt1_files=$(ls ${filepath_trt1}/${year}/${month}/${year}${anmonth}${day}.TRT/*.trw)
 no_trt1_files=$(ls ${filepath_trt1}/${year}/${month}/${year}${anmonth}${day}.TRT/* | wc -l)
 
 python ${SCRIPT_DIR}/../process_wp.py ${trt0_files} -o ${netcdf_path} -t high-mode_15min -m ${metadata_file}

--- a/scripts/make_netcdf.sh
+++ b/scripts/make_netcdf.sh
@@ -39,9 +39,9 @@ esac
 
 
 trt0_files=$(ls ${filepath_trt0}/${year}/${month}/${year}${anmonth}${day}.TRT/*.trw)
-no_trt0_files=$(ls ${filepath_trt0}/${year}/${month}/${year}${anmonth}${day}.TRT/* | wc -l)
+no_trt0_files=$(ls ${filepath_trt0}/${year}/${month}/${year}${anmonth}${day}.TRT/*.trw | wc -l)
 trt1_files=$(ls ${filepath_trt1}/${year}/${month}/${year}${anmonth}${day}.TRT/*.trw)
-no_trt1_files=$(ls ${filepath_trt1}/${year}/${month}/${year}${anmonth}${day}.TRT/* | wc -l)
+no_trt1_files=$(ls ${filepath_trt1}/${year}/${month}/${year}${anmonth}${day}.TRT/*.trw | wc -l)
 
 python ${SCRIPT_DIR}/../process_wp.py ${trt0_files} -o ${netcdf_path} -t high-mode_15min -m ${metadata_file}
 python ${SCRIPT_DIR}/../process_wp.py ${trt1_files} -o ${netcdf_path} -t low-mode_15min -m ${metadata_file}


### PR DESCRIPTION
1. Remove timezone from time_coverage_start and time_coverage_end global attrs - not part of AMOF standard
2. Only include trw files in raw data - other files may be copied from the profiler but are not needed