### PR TITLE
Raise error if no raw files

### DIFF
--- a/process_wp.py
+++ b/process_wp.py
@@ -20,6 +20,10 @@ def make_netcdf_snr_winds(trw_files, metadata_file = None, ncfile_location = '.'
     """
     trw_files - list
     """
+    if len(trw_files) == 0:
+        msg = "No raw data files found!")
+        raise ValueError(msg)
+
     all_data = {}
     all_attrs = {}
     all_unix_times = []


### PR DESCRIPTION
If there are no raw files provided, raise error before trying to do anything, rather than having an error raised later when trying to find something that doesn't exist.