### PR TITLE
Remove a braking bracket

### DIFF
--- a/process_wp.py
+++ b/process_wp.py
@@ -21,7 +21,7 @@ def make_netcdf_snr_winds(trw_files, metadata_file = None, ncfile_location = '.'
     trw_files - list
     """
     if len(trw_files) == 0:
-        msg = "No raw data files found!")
+        msg = "No raw data files found!"
         raise ValueError(msg)
 
     all_data = {}


### PR DESCRIPTION
A stray bracket was causing the script to fail. The offending bracket has been removed.